### PR TITLE
Replace procedural nested array functions, use $form_state['controller']

### DIFF
--- a/tmgmt_ui/tmgmt_ui.module
+++ b/tmgmt_ui/tmgmt_ui.module
@@ -3,6 +3,7 @@
 use Drupal\tmgmt\Plugin\Core\Entity\Job;
 use Drupal\tmgmt\Plugin\Core\Entity\JobItem;
 use Drupal\tmgmt\TranslatorRejectDataInterface;
+use Drupal\Component\Utility\NestedArray;
 
 /**
  * @file
@@ -605,7 +606,7 @@ function tmgmt_ui_translation_review_form_update_state($form, &$form_state) {
  */
 function tmgmt_ui_translation_review_form_ajax($form, &$form_state) {
   $key = array_slice($form_state['triggering_element']['#array_parents'], 0, 2);
-  $render_data = drupal_array_get_nested_value($form, $key);
+  $render_data = NestedArray::getValue($form, $key);
   tmgmt_ui_write_request_messages($form_state['item']->getJob());
   return drupal_render($render_data);
 }

--- a/tmgmt_ui/tmgmt_ui.module
+++ b/tmgmt_ui/tmgmt_ui.module
@@ -526,7 +526,7 @@ function _tmgmt_ui_review_form_element(&$form_state, $data, JobItem $job_item, &
 function tmgmt_ui_translation_review_form_revert($form, &$form_state) {
 
   /** @var JobItem $item */
-  $item = $form_state['item'];
+  $item = $form_state['controller']->getEntity();
 
   $key = tmgmt_ensure_keys_array($form_state['triggering_element']['#data_item_key']);
 
@@ -554,7 +554,7 @@ function tmgmt_ui_translation_review_form_update_state($form, &$form_state) {
   preg_match("/^(?P<action>[^-]+)-(?P<key>.+)/i", $form_state['triggering_element']['#name'], $matches);
   $values = $form_state['values'];
   $data = array();
-  $job_item = $form_state['item'];
+  $job_item = $form_state['controller']->getEntity();
 
   $controller = $job_item->getTranslatorController();
   $success = TRUE;
@@ -607,7 +607,7 @@ function tmgmt_ui_translation_review_form_update_state($form, &$form_state) {
 function tmgmt_ui_translation_review_form_ajax($form, &$form_state) {
   $key = array_slice($form_state['triggering_element']['#array_parents'], 0, 2);
   $render_data = NestedArray::getValue($form, $key);
-  tmgmt_ui_write_request_messages($form_state['item']->getJob());
+  tmgmt_ui_write_request_messages($form_state['controller']->getEntity()->getJob());
   return drupal_render($render_data);
 }
 

--- a/translators/tmgmt_local/entity/tmgmt_local.entity.task_item.inc
+++ b/translators/tmgmt_local/entity/tmgmt_local.entity.task_item.inc
@@ -5,6 +5,8 @@
  * Entity class.
  */
 
+use Drupal\Component\Utility\NestedArray;
+
 /**
  * Entity class for the local task item entity.
  *
@@ -184,7 +186,7 @@ class TMGMTLocalTaskItem extends Entity {
       }
       // Apply the value.
       else {
-        drupal_array_set_nested_value($this->data, array_merge(tmgmt_ensure_keys_array($key), array($index)), $value);
+        NestedArray::setValue($this->data, array_merge(tmgmt_ensure_keys_array($key), array($index)), $value);
       }
     }
   }
@@ -216,7 +218,7 @@ class TMGMTLocalTaskItem extends Entity {
     if ($index) {
       $key = array_merge($key, array($index));
     }
-    return drupal_array_get_nested_value($this->data, $key);
+    return NestedArray::getValue($this->data, $key);
   }
 
   /**

--- a/translators/tmgmt_local/includes/tmgmt_local.pages.inc
+++ b/translators/tmgmt_local/includes/tmgmt_local.pages.inc
@@ -5,6 +5,8 @@
  * Provides page and forms callbacks.
  */
 
+use Drupal\Component\Utility\NestedArray;
+
 /**
  * Simple page callback for viewing a task.
  *
@@ -385,7 +387,7 @@ function tmgmt_local_translation_form_update_state_submit($form, &$form_state) {
 function tmgmt_local_translation_form_update_state_ajax($form, &$form_state) {
   $key = array_slice($form_state['triggering_element']['#array_parents'], 0, 3);
   $commands = array();
-  $render_data = drupal_array_get_nested_value($form, $key);
+  $render_data = NestedArray::getValue($form, $key);
   $commands[] = ajax_command_replace(NULL, drupal_render($render_data));
   tmgmt_ui_write_request_messages($form_state['job_item']->getJob());
   $commands[] = ajax_command_html('#tmgmt-status-messages-' . strtolower($render_data['#parent_label'][0]), theme('status_messages'));


### PR DESCRIPTION
- Replace procedural nested array functions as described in following change record: https://drupal.org/node/1870678
- Use the new $form_state['controller'] to fetch the form entity.
